### PR TITLE
No default node, allow nodename for default node

### DIFF
--- a/world.lua
+++ b/world.lua
@@ -1,5 +1,5 @@
 local world = {}
-local world_default_node = { name = "air", param1 = 0, param2 = 0 }
+local world_default_node
 
 -- TODO: Add some protection against direct node modifications, preferably with clear warning message
 function world.clear()
@@ -69,7 +69,7 @@ local function get_pointed_thing(pos, pointed_thing_type)
 end
 
 function world.set_default_node(node)
-	world_default_node = node
+	world_default_node = create_node(node)
 end
 
 function world.get_node(pos)

--- a/world.lua
+++ b/world.lua
@@ -69,7 +69,7 @@ local function get_pointed_thing(pos, pointed_thing_type)
 end
 
 function world.set_default_node(node)
-	world_default_node = create_node(node)
+	world_default_node = node and create_node(node) or nil
 end
 
 function world.get_node(pos)


### PR DESCRIPTION
Remove default node, if default is required it must be always set before running tests.

Either world is empty, tests create test world with `world.layout` or explicitly set default node. better to not assume anything and keep it completely empty unless something is actually defined.

Also allow setting just node name for simple common cases like `world.set_default_node("air")`.