### PR TITLE
Improved Player:do_metadata_inventory_put

### DIFF
--- a/player.lua
+++ b/player.lua
@@ -146,36 +146,73 @@ function Player:send_chat_message(message)
 	return mineunit:execute_on_chat_message(self:get_player_name(), message)
 end
 
+-- TODO: count -1 might be used wrong here, verify against actual engine behavior
+local function swap_stack(toinv, tolist, toindex, frominv, fromlist, fromindex, count)
+	-- Get source stack
+	local stack = frominv:get_stack(fromlist, fromindex)
+
+	-- Move old stack from target to source first, clear source if target is empty
+	local oldstack = toinv:get_stack(tolist, toindex)
+	if count ~= -1 then
+		if oldstack:is_empty() then
+			frominv:set_stack(fromlist, fromindex, nil)
+		elseif frominv:room_for_item(fromlist, oldstack) then
+			frominv:add_item(fromlist, oldstack)
+		end
+	end
+
+	-- Place source stack into target inventory
+	local placedstack = count ~= -1 and stack:take_item(count) or ItemStack(stack)
+	toinv:set_stack(tolist, toindex, placedstack)
+
+	-- Return leftovers to source inventory
+	if count ~= -1 and not stack:is_empty() and frominv:room_for_item(fromlist, stack) then
+		frominv:add_item(fromlist, stack)
+	end
+	return placedstack
+end
+
 -- TODO: do_metadata_inventory_put does not follow exact engine behavior but should be fine for testing simple inv moves
-function Player:do_metadata_inventory_put(pos, listname, index, stack)
-	-- Test if items can be moved
-	local def = core.registered_nodes[core.get_node(pos).name]
-	stack = ItemStack(stack)
-	local can_put_count = stack:get_count()
+-- TODO: It might be simpler and more useful for tests to just discard leftovers and always clear source inventory
+function Player:do_metadata_inventory_put(pos, tolist, toindex, index_or_stack)
+	-- Get node name and definition at target position
+	local name = core.get_node(pos).name
+	local def = core.registered_nodes[name]
+	assert(def, "Player:do_metadata_inventory_put unknown node: "..tostring(name))
+
+	-- Select source inventory based on index_or_stack contents and type
+	local frominv, fromindex
+	if index_or_stack == nil or type(index_or_stack) == "number" then
+		frominv = self:get_inventory()
+		fromindex = index_or_stack or self._wield_index
+	else
+		frominv = InvRef()
+		frominv:set_size("main", 1)
+		frominv:set_stack("main", 1, index_or_stack)
+		fromindex = 1
+	end
+
+	-- Test if target accepts stack and stack can be moved
+	local stack = frominv:get_stack("main", fromindex)
+	local can_put_count
 	if def.allow_metadata_inventory_put then
-		can_put_count = def.allow_metadata_inventory_put(pos, listname, index, stack, self)
+		can_put_count = def.allow_metadata_inventory_put(pos, tolist, toindex, stack, self)
+		assert(type(can_put_count) == "number", "allow_metadata_inventory_put returns invalid value for "..name)
+	else
+		can_put_count = stack:get_count()
 	end
-	-- Move items
-	if can_put_count > 0 then
-		local playerinv = self:get_inventory()
-		local inv = core.get_meta(pos):get_inventory()
-		local oldstack = inv:get_stack(listname, index)
-		if not oldstack:is_empty() and playerinv:room_for_item("main", oldstack) then
-			-- Old stack to player inventory if there's enough space
-			playerinv:add_item("main", oldstack)
-		end
-		-- Place stack into inventory
-		inv:set_stack(listname, index, stack:take_item(can_put_count))
-		-- Return leftovers to player inventory
-		if not stack:is_empty() and playerinv:room_for_item("main", stack) then
-			-- Leftovers to player inventory if there's enough space
-			playerinv:add_item("main", stack)
-		end
-		-- Callbacks
-		if def.on_metadata_inventory_put then
-			def.on_metadata_inventory_put(pos, listname, index, stack, self)
+
+	-- Move items (can_put_count == -1 should pass but leave source unmodified)
+	if can_put_count > 0 or can_put_count == -1 then
+		local toinv = core.get_meta(pos):get_inventory()
+		local placedstack = swap_stack(toinv, tolist, toindex, frominv, "main", fromindex, can_put_count)
+
+		-- Execute callbacks
+		if def.on_metadata_inventory_put and not placedstack:is_empty() then
+			def.on_metadata_inventory_put(pos, tolist, toindex, placedstack, self)
 		end
 	end
+	return can_put_count
 end
 
 function Player:do_metadata_inventory_take(pos, listname, index)

--- a/spec/player_spec.lua
+++ b/spec/player_spec.lua
@@ -9,7 +9,18 @@ describe("Mineunit Player", function()
 	mineunit("entity")
 	mineunit("player")
 
-	core.register_node(":default:stone", {
+	core.register_node(":chest", {
+		description = "chest",
+		buildable_to = false,
+		walkable = true,
+		on_construct = function(pos)
+			local meta = core.get_meta(pos)
+			local inv = meta:get_inventory()
+			inv:set_size("chest", 3)
+		end,
+	})
+
+	core.register_node(":stone", {
 		description = "stone",
 		buildable_to = false,
 		walkable = true,
@@ -78,7 +89,7 @@ describe("Mineunit Player", function()
 		end,
 	})
 
-	world.set_node({x=2,y=0,z=0}, "default:stone")
+	world.set_node({x=2,y=0,z=0}, "stone")
 
 	local SX = Player("SX")
 	SX:get_inventory():set_stack("main", 1, "check")
@@ -283,6 +294,48 @@ describe("Mineunit Player", function()
 				assert.close_enough( 0.49, surface_pos, "surface_pos.z")
 			end
 			SX:do_use({x=1,y=0,z=0})
+		end)
+
+	end)
+
+	describe(":do_metadata_inventory_put(...)", function()
+
+		setup(function()
+			world.place_node({x=0,y=1,z=0}, "chest")
+			local inv = SX:get_inventory()
+			inv:set_stack("main", 1, "stone 33")
+			inv:set_stack("main", 2, "stone 42")
+			inv:set_stack("main", 3, "stone 88")
+		end)
+
+		it("works without source index", function()
+			SX:do_metadata_inventory_put({x=0,y=1,z=0}, "chest", 1)
+			local expected = InvRef()
+			expected:set_size("chest", 3)
+			expected:set_stack("chest", 1, ItemStack("stone 33"))
+			local nodeinv = core.get_meta({x=0,y=1,z=0}):get_inventory()
+			assert.same(tostring(expected:get_list("chest")), tostring(nodeinv:get_list("chest")))
+		end)
+
+		it("works with source index", function()
+			SX:do_metadata_inventory_put({x=0,y=1,z=0}, "chest", 2, 2)
+			local expected = InvRef()
+			expected:set_size("chest", 3)
+			expected:set_stack("chest", 1, ItemStack("stone 33"))
+			expected:set_stack("chest", 2, ItemStack("stone 42"))
+			local nodeinv = core.get_meta({x=0,y=1,z=0}):get_inventory()
+			assert.same(tostring(expected:get_list("chest")), tostring(nodeinv:get_list("chest")))
+		end)
+
+		it("works with ItemStack", function()
+			SX:do_metadata_inventory_put({x=0,y=1,z=0}, "chest", 3, ItemStack("stone 96"))
+			local expected = InvRef()
+			expected:set_size("chest", 3)
+			expected:set_stack("chest", 1, ItemStack("stone 33"))
+			expected:set_stack("chest", 2, ItemStack("stone 42"))
+			expected:set_stack("chest", 3, ItemStack("stone 96"))
+			local nodeinv = core.get_meta({x=0,y=1,z=0}):get_inventory()
+			assert.same(tostring(expected:get_list("chest")), tostring(nodeinv:get_list("chest")))
 		end)
 
 	end)

--- a/world.lua
+++ b/world.lua
@@ -12,6 +12,8 @@ function world.clear()
 				node = table.copy(node)
 				node.name = resolved
 			end
+			-- TODO: Add option for stricter validation of nodes added to world
+			--assert(core.registered_nodes[node.name], "Attempt to place invalid node: "..tostring(node.name))
 			rawset(self, key, node)
 		end,
 	})


### PR DESCRIPTION
Simpler to use and also follows engine implementation bit better.
Should not break previous use cases.

* By default take items from current player wield slot.
* If index number is given take from that player inventory slot.
* If ItemStack is given create temporary inventory and use that for moves.