### PR TITLE
Fix player priv check

### DIFF
--- a/player.lua
+++ b/player.lua
@@ -26,23 +26,33 @@ function _G.core.set_player_privs(name, privs)
 	players[name]._privs = new_privs
 end
 
-function _G.core.check_player_privs(player_or_name, ...)
-	assert.player_or_name(player_or_name, "core.check_player_privs: player_or_name: expected string or Player")
-	local player
-	if type(player_or_name) == "string" then
-		player = core.get_player_by_name(player_or_name)
-	else
-		player = player_or_name
-	end
-	assert.is_Player(player, "core.check_player_privs: player does not exist or is not online")
-	local missing_privs = {}
-	local arg={...}
-	for _,priv in ipairs(type(arg[1]) == "table" and arg[1] or arg) do
-		if not player._privs[priv] then
-			table.insert(missing_privs, priv)
+if not _G.core.check_player_privs then
+	function _G.core.check_player_privs(player_or_name, ...)
+		assert.player_or_name(player_or_name, "core.check_player_privs: player_or_name: expected string or Player")
+		local player
+		if type(player_or_name) == "string" then
+			player = core.get_player_by_name(player_or_name)
+		else
+			player = player_or_name
 		end
+		assert.is_Player(player, "core.check_player_privs: player does not exist or is not online")
+		local missing_privs = {}
+		local arg={...}
+		if type(arg[1]) == "table" then
+			for priv,_ in pairs(arg[1]) do
+				if not player._privs[priv] then
+					table.insert(missing_privs, priv)
+				end
+			end
+		else
+			for _,priv in ipairs(arg) do
+				if not player._privs[priv] then
+					table.insert(missing_privs, priv)
+				end
+			end
+		end
+		return #missing_privs == 0, #missing_privs > 0 and missing_privs or ""
 	end
-	return #missing_privs == 0, missing_privs
 end
 
 function _G.core.get_player_by_name(name)

--- a/spec/player_bare_spec.lua
+++ b/spec/player_bare_spec.lua
@@ -1,0 +1,95 @@
+-- For self tests package path must be set in a way that makes package loaders search current directory first
+package.path = "./?.lua;../?/init.lua;../?.lua;" --.. package.path
+
+describe("Mineunit Player", function()
+
+	require("mineunit")
+	mineunit("itemstack")
+	sourcefile("player")
+
+	describe("core.check_player_privs (player)", function()
+
+		-- For some reason engine returns empty string instead of empty table if no privileges missing.
+		-- This is really what engine does and it is not mistake in following tests.
+
+		it("Player success no privileges", function()
+			local player = Player("p1", {})
+			local expected_result = true
+			local expected_missing = ""
+			local result, missing = core.check_player_privs(player, {})
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player fail missing privilege", function()
+			local player = Player("p2", {})
+			local expected_result = false
+			local expected_missing = { "p2" }
+			local result, missing = core.check_player_privs(player, { p2 = true })
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player success 1 privilege", function()
+			local player = Player("p3", { p3 = true })
+			local expected_result = true
+			local expected_missing = ""
+			local result, missing = core.check_player_privs(player, { p3 = true })
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player fail 1 privilege", function()
+			local player = Player("p4", { p4b = true })
+			local expected_result = false
+			-- For some reason engine returns empty string if no privileges missing
+			local expected_missing = { "p4" }
+			local result, missing = core.check_player_privs(player, { p4 = true })
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player success 2 privileges", function()
+			local player = Player("p5", { p5a = true, p5b = true })
+			local expected_result = true
+			-- For some reason engine returns empty string if no privileges missing
+			local expected_missing = ""
+			local result, missing = core.check_player_privs(player, { p5a = true, p5b = true })
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player fail 2 privileges", function()
+			local player = Player("p6", { p6a = true, p6b = true })
+			local expected_result = false
+			-- For some reason engine returns empty string if no privileges missing
+			local expected_missing = { "p6c", "p6d" }
+			local result, missing = core.check_player_privs(player, { p6c = true, p6d = true })
+			assert.equals(expected_result, result)
+			table.sort(missing)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player success excess player privileges", function()
+			local player = Player("p7", { p7a = true, p7b = true })
+			local expected_result = true
+			-- For some reason engine returns empty string if no privileges missing
+			local expected_missing = ""
+			local result, missing = core.check_player_privs(player, { p7b = true })
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player fail excess required privileges", function()
+			local player = Player("p8", { p8a = true, p8b = true })
+			local expected_result = false
+			-- For some reason engine returns empty string if no privileges missing
+			local expected_missing = { "p8d" }
+			local result, missing = core.check_player_privs(player, { p8b = true, p8d = true })
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+	end)
+
+end)

--- a/spec/player_spec.lua
+++ b/spec/player_spec.lua
@@ -408,4 +408,89 @@ describe("Mineunit Player", function()
 
 	end)
 
+	describe("core.check_player_privs (engine)", function()
+
+		-- For some reason engine returns empty string instead of empty table if no privileges missing.
+		-- This is really what engine does and it is not mistake in following tests.
+
+		it("Player success no privileges", function()
+			local player = Player("p1", {})
+			local expected_result = true
+			local expected_missing = ""
+			local result, missing = core.check_player_privs(player, {})
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player fail missing privilege", function()
+			local player = Player("p2", {})
+			local expected_result = false
+			local expected_missing = { "p2" }
+			local result, missing = core.check_player_privs(player, { p2 = true })
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player success 1 privilege", function()
+			local player = Player("p3", { p3 = true })
+			local expected_result = true
+			local expected_missing = ""
+			local result, missing = core.check_player_privs(player, { p3 = true })
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player fail 1 privilege", function()
+			local player = Player("p4", { p4b = true })
+			local expected_result = false
+			-- For some reason engine returns empty string if no privileges missing
+			local expected_missing = { "p4" }
+			local result, missing = core.check_player_privs(player, { p4 = true })
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player success 2 privileges", function()
+			local player = Player("p5", { p5a = true, p5b = true })
+			local expected_result = true
+			-- For some reason engine returns empty string if no privileges missing
+			local expected_missing = ""
+			local result, missing = core.check_player_privs(player, { p5a = true, p5b = true })
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player fail 2 privileges", function()
+			local player = Player("p6", { p6a = true, p6b = true })
+			local expected_result = false
+			-- For some reason engine returns empty string if no privileges missing
+			local expected_missing = { "p6c", "p6d" }
+			local result, missing = core.check_player_privs(player, { p6c = true, p6d = true })
+			assert.equals(expected_result, result)
+			table.sort(missing)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player success excess player privileges", function()
+			local player = Player("p7", { p7a = true, p7b = true })
+			local expected_result = true
+			-- For some reason engine returns empty string if no privileges missing
+			local expected_missing = ""
+			local result, missing = core.check_player_privs(player, { p7b = true })
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+		it("Player fail excess required privileges", function()
+			local player = Player("p8", { p8a = true, p8b = true })
+			local expected_result = false
+			-- For some reason engine returns empty string if no privileges missing
+			local expected_missing = { "p8d" }
+			local result, missing = core.check_player_privs(player, { p8b = true, p8d = true })
+			assert.equals(expected_result, result)
+			assert.same(expected_missing, missing)
+		end)
+
+	end)
+
 end)


### PR DESCRIPTION
Fixes `core.check_player_privs` when only bare player module is loaded.