### PR TITLE
Implement ItemStack:{get,set}_metadata

### DIFF
--- a/itemstack.lua
+++ b/itemstack.lua
@@ -33,9 +33,19 @@ end
 --* `get_meta()`: returns ItemStackMetaRef. See section for more details
 function ItemStack:get_meta() return self._meta end
 --* `get_metadata()`: (DEPRECATED) Returns metadata (a string attached to an item stack).
-function ItemStack:get_metadata() DEPRECATED("Using deprecated ItemStack:get_metadata()") end
+function ItemStack:get_metadata()
+	return self._meta:get_string("")
+end
 --* `set_metadata(metadata)`: (DEPRECATED) Returns true.
-function ItemStack:set_metadata(metadata) DEPRECATED("Using deprecated ItemStack:set_metadata(metadata)") end
+function ItemStack:set_metadata(metadata)
+	if type(metadata) == "number" then
+		metadata = tostring(metadata)
+	else
+		assert.is_string(metadata, "ItemStack:set_metadata expects metadata to be string")
+	end
+	self._meta:set_string("", metadata)
+	return true
+end
 --* `get_description()`: returns the description shown in inventory list tooltips.
 --    The engine uses the same as this function for item descriptions.
 --    Fields for finding the description, in order:


### PR DESCRIPTION
I ran into this issue when writing tests for Mesecons. I looked at the code of Minetest to replicate its behavior. Because I'm not actually copying the code, I would think this would be OK license-wise, but I'm not knowledgeable about such things. If incorporating these changes would cause legal issues, this PR should be closed, and you should not look at the changes.