### PR TITLE
Implement non-mapgen VoxelManip functionality

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -106,7 +106,7 @@ _G.minetest.after = noop
 _G.minetest.find_nodes_with_meta = _G.world.find_nodes_with_meta
 _G.minetest.find_nodes_in_area = _G.world.find_nodes_in_area
 _G.minetest.get_node_or_nil = _G.world.get_node
-_G.minetest.get_node = function(pos) return minetest.get_node_or_nil(pos) or {name="ignore",param2=0} end
+_G.minetest.get_node = function(pos) return minetest.get_node_or_nil(pos) or {name="ignore",param1=0,param2=0} end
 _G.minetest.dig_node = function(pos) return world.on_dig(pos) and true or false end
 _G.minetest.remove_node = _G.world.remove_node
 

--- a/spec/voxelmanip_spec.lua
+++ b/spec/voxelmanip_spec.lua
@@ -1,0 +1,104 @@
+
+-- For self tests package path must be set in a way that makes package loaders search current directory first
+package.path = "./?.lua;../?/init.lua;../?.lua;" --.. package.path
+
+describe("VoxelManip", function()
+
+	require("mineunit")
+	sourcefile("voxelmanip")
+	mineunit("core")
+	mineunit("common/vector")
+	mineunit("world")
+
+	mineunit:set_current_modname("test")
+	minetest.register_node("test:node", {})
+	minetest.register_node("test:node2", {})
+
+	local vm
+
+	before_each(function()
+		world.clear()
+		world.layout({
+			{vector.new(0, 0, 0), "test:node"},
+			{vector.new(20, 0, 0), "test:node"},
+			{vector.new(0, 20, 0), "test:node"},
+		})
+		vm = VoxelManip(vector.new(0, 0, 0), vector.new(20, 0, 0))
+		vm:read_from_map(vector.new(0, 0, 0), vector.new(0, 20, 0))
+	end)
+
+	it("nodes", function()
+		assert.same({name = "test:node", param1 = 0, param2 = 0}, vm:get_node_at(vector.new(0, 0, 0)))
+		assert.same({name = "ignore", param1 = 0, param2 = 0}, vm:get_node_at(vector.new(1, 1, 1)))
+		assert.same({name = "ignore", param1 = 0, param2 = 0}, vm:get_node_at(vector.new(17, 17, 0)))
+		assert.same({name = "ignore", param1 = 0, param2 = 0}, vm:get_node_at(vector.new(100, 100, 100)))
+		vm:set_node_at(vector.new(0, 0, 0), {name = "test:node2"})
+		vm:set_node_at(vector.new(1, 1, 1), {name = "test:node2"})
+		vm:set_node_at(vector.new(17, 17, 0), {name = "test:node2"})
+		vm:set_node_at(vector.new(100, 100, 100), {name = "test:node2"})
+		assert.same({name = "test:node2", param1 = 0, param2 = 0}, vm:get_node_at(vector.new(0, 0, 0)))
+		assert.same({name = "test:node2", param1 = 0, param2 = 0}, vm:get_node_at(vector.new(1, 1, 1)))
+		assert.same({name = "ignore", param1 = 0, param2 = 0}, vm:get_node_at(vector.new(17, 17, 0)))
+		assert.same({name = "ignore", param1 = 0, param2 = 0}, vm:get_node_at(vector.new(100, 100, 100)))
+	end)
+
+	it("get data", function()
+		local data = vm:get_data()
+		local param1_data = vm:get_light_data()
+		local param2_data = vm:get_param2_data()
+		local emin, emax = vm:get_emerged_area()
+		local p = vector.new(emin)
+		local i = 1
+		while p.z <= emax.z do
+			while p.y <= emax.y do
+				while p.x <= emax.x do
+					local node1 = vm:get_node_at(p)
+					local node2 = {
+						name = minetest.get_name_from_content_id(data[i]),
+						param1 = param1_data[i], param2 = param2_data[i],
+					}
+					assert.same(node1, node2)
+					i = i + 1
+					p.x = p.x + 1
+				end
+				p.x = emin.x
+				p.y = p.y + 1
+			end
+			p.y = emin.y
+			p.z = p.z + 1
+		end
+	end)
+
+	it("set data", function()
+		local data = {}
+		local param1_data = {}
+		local param2_data = {}
+		local content_id = minetest.get_content_id("test:node2")
+		local emin, emax = vm:get_emerged_area()
+		local volume = (emax.x - emin.x + 1) * (emax.y - emin.y + 1) * (emax.z - emin.z + 1)
+		for i = 1, volume do
+			data[i] = content_id
+			param1_data[i] = 2
+			param2_data[i] = 1
+		end
+		vm:set_data(data)
+		vm:set_light_data(param1_data)
+		vm:set_param2_data(param2_data)
+		assert.same({name = "test:node2", param1 = 2, param2 = 1}, vm:get_node_at(vector.new(0, 0, 0)))
+		assert.same({name = "test:node2", param1 = 2, param2 = 1}, vm:get_node_at(vector.new(1, 1, 1)))
+		assert.same({name = "ignore", param1 = 0, param2 = 0}, vm:get_node_at(vector.new(17, 17, 0)))
+		assert.same({name = "ignore", param1 = 0, param2 = 0}, vm:get_node_at(vector.new(100, 100, 100)))
+	end)
+
+	it("write", function()
+		vm:set_node_at(vector.new(0, 0, 0), {name = "test:node2"})
+		vm:set_node_at(vector.new(1, 1, 1), {name = "test:node2"})
+		vm:set_node_at(vector.new(17, 17, 0), {name = "test:node2"})
+		vm:set_node_at(vector.new(100, 100, 100), {name = "test:node2"})
+		vm:write_to_map()
+		assert.same({name = "test:node2", param1 = 0, param2 = 0}, minetest.get_node(vector.new(0, 0, 0)))
+		assert.same({name = "test:node2", param1 = 0, param2 = 0}, minetest.get_node(vector.new(1, 1, 1)))
+		assert.same({name = "ignore", param1 = 0, param2 = 0}, minetest.get_node(vector.new(17, 17, 0)))
+		assert.same({name = "ignore", param1 = 0, param2 = 0}, minetest.get_node(vector.new(100, 100, 100)))
+	end)
+end)

--- a/spec/voxelmanip_spec.lua
+++ b/spec/voxelmanip_spec.lua
@@ -47,25 +47,19 @@ describe("VoxelManip", function()
 		local param1_data = vm:get_light_data()
 		local param2_data = vm:get_param2_data()
 		local emin, emax = vm:get_emerged_area()
-		local p = vector.new(emin)
 		local i = 1
-		while p.z <= emax.z do
-			while p.y <= emax.y do
-				while p.x <= emax.x do
-					local node1 = vm:get_node_at(p)
+		for z = emin.z, emax.z do
+			for y = emin.y, emax.y do
+				for x = emin.x, emax.x do
+					local node1 = vm:get_node_at(vector.new(x, y, z))
 					local node2 = {
 						name = minetest.get_name_from_content_id(data[i]),
 						param1 = param1_data[i], param2 = param2_data[i],
 					}
 					assert.same(node1, node2)
 					i = i + 1
-					p.x = p.x + 1
 				end
-				p.x = emin.x
-				p.y = p.y + 1
 			end
-			p.y = emin.y
-			p.z = p.z + 1
 		end
 	end)
 

--- a/voxelmanip.lua
+++ b/voxelmanip.lua
@@ -36,11 +36,8 @@ end
 
 local ignore_node = {name = "ignore", param1 = 0, param2 = 0}
 
--- This must be a separate object from ignore_node.
-local unloaded_node = {name = "ignore", param1 = 0, param2 = 0}
-
 local nodes_mt = {
-	__index = function() return unloaded_node end,
+	__index = function() return ignore_node end,
 	-- This prevents addition of nodes outside loaded areas:
 	__newindex = function() end,
 }
@@ -93,8 +90,8 @@ function VoxelManip:write_to_map()
 		while p.y <= emax.y do
 			while p.x <= emax.x do
 				local hash = core.hash_node_position(p)
-				local node = self._nodes[hash]
-				if node ~= unloaded_node then
+				local node = rawget(self._nodes, hash)
+				if node then
 					world.nodes[hash] = node
 				end
 				p.x = p.x + 1

--- a/voxelmanip.lua
+++ b/voxelmanip.lua
@@ -98,7 +98,7 @@ end
 function VoxelManip:get_node_at(pos)
 	local node = self._nodes[core.hash_node_position(pos)]
 	if node.unloaded then
-		node = ignore_node
+		node = unloaded_node
 	end
 	return {name = node.name, param1 = node.param1, param2 = node.param2}
 end

--- a/voxelmanip.lua
+++ b/voxelmanip.lua
@@ -1,37 +1,348 @@
+mineunit("common/vector")
+mineunit("world")
+
 local VoxelManip = {}
 
-function blockpos(p)
-	return math.floor(p / 16)
+local function pos2blockpos(p)
+	return vector.floor(vector.divide(p, core.MAP_BLOCKSIZE))
 end
 
-function nodepos_min(p)
-	return p * 16
+local function block_min_pos(bp)
+	return vector.multiply(bp, core.MAP_BLOCKSIZE)
 end
 
-function nodepos_max(p)
-	return p * 16 + 15
+local function block_max_pos(bp)
+	return vector.add(block_min_pos(bp), core.MAP_BLOCKSIZE - 1)
 end
 
-local function mapblock_area(pos)
-	local bx, by, bz = blockpos(pos.x), blockpos(pos.y), blockpos(pos.z)
-	return 
-		{ x = nodepos_min(bx), y = nodepos_min(by), z = nodepos_min(bz) },
-		{ x = nodepos_max(bx), y = nodepos_max(by), z = nodepos_max(bz) }
+local function sort_box(minp, maxp)
+	minp.x, maxp.x = math.min(minp.x, maxp.x), math.max(minp.x, maxp.x)
+	minp.y, maxp.y = math.min(minp.y, maxp.y), math.max(minp.y, maxp.y)
+	minp.z, maxp.z = math.min(minp.z, maxp.z), math.max(minp.z, maxp.z)
 end
+
+local ignore_node = {name = "ignore", param1 = 0, param2 = 0}
+local nodes_mt = {__index = function() return ignore_node end}
 
 --
 -- VoxelManip public API
 --
 
-function VoxelManip:read_from_map(pos1, pos2)
-	return mapblock_area(pos1)[1], mapblock_area(pos2)[2]
+function VoxelManip:get_emerged_area()
+	return vector.new(self._emin), vector.new(self._emax)
+end
+
+function VoxelManip:read_from_map(p1, p2)
+	local bpmin = pos2blockpos(p1)
+	local bpmax = pos2blockpos(p2)
+	sort_box(bpmin, bpmax)
+
+	local minp = block_min_pos(bpmin)
+	local maxp = block_max_pos(bpmax)
+
+	self._emin.x = math.min(self._emin.x, minp.x)
+	self._emin.y = math.min(self._emin.y, minp.y)
+	self._emin.z = math.min(self._emin.z, minp.z)
+	self._emax.x = math.max(self._emax.x, maxp.x)
+	self._emax.y = math.max(self._emax.y, maxp.y)
+	self._emax.z = math.max(self._emax.z, maxp.z)
+
+	local p = vector.new(minp)
+	while p.z <= maxp.z do
+		while p.y <= maxp.y do
+			while p.x <= maxp.x do
+				local hash = core.hash_node_position(p)
+				self._nodes[hash] = world.nodes[hash]
+				p.x = p.x + 1
+			end
+			p.x = minp.x
+			p.y = p.y + 1
+		end
+		p.y = minp.y
+		p.z = p.z + 1
+	end
+
+	local bp = vector.new(bpmin)
+	while bp.z <= bpmax.z do
+		while bp.y <= bpmax.y do
+			while bp.x <= bpmax.x do
+				self._block_set[core.hash_node_position(bp)] = true
+				bp.x = bp.x + 1
+			end
+			bp.x = bpmin.x
+			bp.y = bp.y + 1
+		end
+		bp.y = bpmin.y
+		bp.z = bp.z + 1
+	end
+
+	return self:get_emerged_area()
+end
+
+function VoxelManip:write_to_map()
+	for bphash in pairs(self._block_set) do
+		local bp = core.get_position_from_hash(bphash)
+		local minp = block_min_pos(bp)
+		local maxp = block_max_pos(bp)
+		local p = vector.new(minp)
+		while p.z <= maxp.z do
+			while p.y <= maxp.y do
+				while p.x <= maxp.x do
+					local hash = core.hash_node_position(p)
+					world.nodes[hash] = self._nodes[hash]
+					p.x = p.x + 1
+				end
+				p.x = minp.x
+				p.y = p.y + 1
+			end
+			p.y = minp.y
+			p.z = p.z + 1
+		end
+	end
+end
+
+function VoxelManip:update_liquids()
+end
+
+function VoxelManip:update_map()
+end
+
+function VoxelManip:get_node_at(pos)
+	local node = self._nodes[core.hash_node_position(pos)]
+	return {name = node.name, param1 = node.param1, param2 = node.param2}
+end
+
+function VoxelManip:set_node_at(pos, node)
+	if self._block_set[core.hash_node_position(pos2blockpos(pos))] then
+		node = {name = node.name, param1 = node.param1 or 0, param2 = node.param2 or 0}
+		local nodedef = core.registered_nodes[node.name]
+		if nodedef == nil then
+			error("Invalid node name '" .. tostring(node.name) .. "'")
+		end
+		node.name = nodedef.name
+		self._nodes[core.hash_node_position(pos)] = node
+	end
+end
+
+function VoxelManip:get_data(buf)
+	buf = buf or {}
+
+	local emin, emax = self._emin, self._emax
+	local i = 1
+	local p = vector.new(emin)
+	while p.z <= emax.z do
+		while p.y <= emax.y do
+			while p.x <= emax.x do
+				local node = self._nodes[core.hash_node_position(p)]
+				buf[i] = core.get_content_id(node.name)
+				i = i + 1
+				p.x = p.x + 1
+			end
+			p.x = emin.x
+			p.y = p.y + 1
+		end
+		p.y = emin.y
+		p.z = p.z + 1
+	end
+
+	return buf
+end
+
+function VoxelManip:get_light_data()
+	local buf = {}
+
+	local emin, emax = self._emin, self._emax
+	local i = 1
+	local p = vector.new(emin)
+	while p.z <= emax.z do
+		while p.y <= emax.y do
+			while p.x <= emax.x do
+				local node = self._nodes[core.hash_node_position(p)]
+				buf[i] = node.param1
+				i = i + 1
+				p.x = p.x + 1
+			end
+			p.x = emin.x
+			p.y = p.y + 1
+		end
+		p.y = emin.y
+		p.z = p.z + 1
+	end
+
+	return buf
+end
+
+function VoxelManip:get_param2_data(buf)
+	buf = buf or {}
+
+	local emin, emax = self._emin, self._emax
+	local i = 1
+	local p = vector.new(emin)
+	while p.z <= emax.z do
+		while p.y <= emax.y do
+			while p.x <= emax.x do
+				local node = self._nodes[core.hash_node_position(p)]
+				buf[i] = node.param2
+				i = i + 1
+				p.x = p.x + 1
+			end
+			p.x = emin.x
+			p.y = p.y + 1
+		end
+		p.y = emin.y
+		p.z = p.z + 1
+	end
+
+	return buf
+end
+
+function VoxelManip:set_data(buf)
+	local emin, emax = self._emin, self._emax
+	local i = 1
+	local p = vector.new(emin)
+	while p.z <= emax.z do
+		while p.y <= emax.y do
+			while p.x <= emax.x do
+				local hash = core.hash_node_position(p)
+				local oldnode = self._nodes[hash]
+				self._nodes[hash] = {
+					name = core.get_name_from_content_id(buf[i]),
+					param1 = oldnode.param1,
+					param2 = oldnode.param2,
+				}
+				i = i + 1
+				p.x = p.x + 1
+			end
+			p.x = emin.x
+			p.y = p.y + 1
+		end
+		p.y = emin.y
+		p.z = p.z + 1
+	end
+
+	return buf
+end
+
+function VoxelManip:get_light_data()
+	local buf = {}
+
+	local emin, emax = self._emin, self._emax
+	local i = 1
+	local p = vector.new(emin)
+	while p.z <= emax.z do
+		while p.y <= emax.y do
+			while p.x <= emax.x do
+				local node = self._nodes[core.hash_node_position(p)]
+				buf[i] = node.param1
+				i = i + 1
+				p.x = p.x + 1
+			end
+			p.x = emin.x
+			p.y = p.y + 1
+		end
+		p.y = emin.y
+		p.z = p.z + 1
+	end
+
+	return buf
+end
+
+function VoxelManip:set_light_data(buf)
+	local emin, emax = self._emin, self._emax
+	local i = 1
+	local p = vector.new(emin)
+	while p.z <= emax.z do
+		while p.y <= emax.y do
+			while p.x <= emax.x do
+				local hash = core.hash_node_position(p)
+				local oldnode = self._nodes[hash]
+				self._nodes[hash] = {
+					name = oldnode.name,
+					param1 = buf[i],
+					param2 = oldnode.param2,
+				}
+				i = i + 1
+				p.x = p.x + 1
+			end
+			p.x = emin.x
+			p.y = p.y + 1
+		end
+		p.y = emin.y
+		p.z = p.z + 1
+	end
+
+	return buf
+end
+
+function VoxelManip:get_param2_data(buf)
+	buf = buf or {}
+
+	local emin, emax = self._emin, self._emax
+	local i = 1
+	local p = vector.new(emin)
+	while p.z <= emax.z do
+		while p.y <= emax.y do
+			while p.x <= emax.x do
+				local node = self._nodes[core.hash_node_position(p)]
+				buf[i] = node.param2
+				i = i + 1
+				p.x = p.x + 1
+			end
+			p.x = emin.x
+			p.y = p.y + 1
+		end
+		p.y = emin.y
+		p.z = p.z + 1
+	end
+
+	return buf
+end
+
+function VoxelManip:set_param2_data(buf)
+	local emin, emax = self._emin, self._emax
+	local i = 1
+	local p = vector.new(emin)
+	while p.z <= emax.z do
+		while p.y <= emax.y do
+			while p.x <= emax.x do
+				local hash = core.hash_node_position(p)
+				local oldnode = self._nodes[hash]
+				self._nodes[hash] = {
+					name = oldnode.name,
+					param1 = oldnode.param1,
+					param2 = buf[i],
+				}
+				i = i + 1
+				p.x = p.x + 1
+			end
+			p.x = emin.x
+			p.y = p.y + 1
+		end
+		p.y = emin.y
+		p.z = p.z + 1
+	end
+
+	return buf
 end
 
 mineunit.export_object(VoxelManip, {
 	name = "VoxelManip",
-	constructor = function(self)
-		local obj = {}
-		setmetatable(obj, VoxelManip)
-		return obj
+	constructor = function(self, p1, p2)
+		local vm = {
+			_block_set = {},
+			-- These nodes must not mutate.
+			_nodes = setmetatable({}, nodes_mt),
+			_emin = vector.new(1, 1, 1),
+			_emax = vector.new(0, 0, 0),
+		}
+		setmetatable(vm, self)
+		if type(p1) == "table" and type(p2) == "table" then
+			vm:read_from_map(p1, p2)
+		end
+		return vm
 	end,
 })
+
+function core.get_voxel_manip(p1, p2)
+	return VoxelManip(p1, p2)
+end

--- a/voxelmanip.lua
+++ b/voxelmanip.lua
@@ -123,8 +123,7 @@ function VoxelManip:get_data(buf)
 	while p.z <= emax.z do
 		while p.y <= emax.y do
 			while p.x <= emax.x do
-				local node = self._nodes[core.hash_node_position(p)]
-				buf[i] = core.get_content_id(node.name)
+				buf[i] = core.get_content_id(self._nodes[core.hash_node_position(p)].name)
 				i = i + 1
 				p.x = p.x + 1
 			end
@@ -147,8 +146,7 @@ function VoxelManip:get_light_data()
 	while p.z <= emax.z do
 		while p.y <= emax.y do
 			while p.x <= emax.x do
-				local node = self._nodes[core.hash_node_position(p)]
-				buf[i] = node.param1
+				buf[i] = self._nodes[core.hash_node_position(p)].param1
 				i = i + 1
 				p.x = p.x + 1
 			end
@@ -171,8 +169,7 @@ function VoxelManip:get_param2_data(buf)
 	while p.z <= emax.z do
 		while p.y <= emax.y do
 			while p.x <= emax.x do
-				local node = self._nodes[core.hash_node_position(p)]
-				buf[i] = node.param2
+				buf[i] = self._nodes[core.hash_node_position(p)].param2
 				i = i + 1
 				p.x = p.x + 1
 			end
@@ -214,30 +211,6 @@ function VoxelManip:set_data(buf)
 	return buf
 end
 
-function VoxelManip:get_light_data()
-	local buf = {}
-
-	local emin, emax = self._emin, self._emax
-	local i = 1
-	local p = vector.new(emin)
-	while p.z <= emax.z do
-		while p.y <= emax.y do
-			while p.x <= emax.x do
-				local node = self._nodes[core.hash_node_position(p)]
-				buf[i] = node.param1
-				i = i + 1
-				p.x = p.x + 1
-			end
-			p.x = emin.x
-			p.y = p.y + 1
-		end
-		p.y = emin.y
-		p.z = p.z + 1
-	end
-
-	return buf
-end
-
 function VoxelManip:set_light_data(buf)
 	local emin, emax = self._emin, self._emax
 	local i = 1
@@ -253,30 +226,6 @@ function VoxelManip:set_light_data(buf)
 					param2 = oldnode.param2,
 					unloaded = oldnode.unloaded,
 				}
-				i = i + 1
-				p.x = p.x + 1
-			end
-			p.x = emin.x
-			p.y = p.y + 1
-		end
-		p.y = emin.y
-		p.z = p.z + 1
-	end
-
-	return buf
-end
-
-function VoxelManip:get_param2_data(buf)
-	buf = buf or {}
-
-	local emin, emax = self._emin, self._emax
-	local i = 1
-	local p = vector.new(emin)
-	while p.z <= emax.z do
-		while p.y <= emax.y do
-			while p.x <= emax.x do
-				local node = self._nodes[core.hash_node_position(p)]
-				buf[i] = node.param2
 				i = i + 1
 				p.x = p.x + 1
 			end

--- a/voxelmanip.lua
+++ b/voxelmanip.lua
@@ -1,4 +1,5 @@
 mineunit("common/vector")
+mineunit("game/misc")
 mineunit("world")
 
 local VoxelManip = {}

--- a/voxelmanip.lua
+++ b/voxelmanip.lua
@@ -10,6 +10,7 @@
 --    set_data() etc. This is very unlikely to be a problem.
 
 mineunit("common/vector")
+mineunit("core")
 mineunit("game/misc")
 mineunit("world")
 

--- a/voxelmanip.lua
+++ b/voxelmanip.lua
@@ -97,6 +97,9 @@ end
 
 function VoxelManip:get_node_at(pos)
 	local node = self._nodes[core.hash_node_position(pos)]
+	if node.unloaded then
+		node = ignore_node
+	end
 	return {name = node.name, param1 = node.param1, param2 = node.param2}
 end
 

--- a/voxelmanip.lua
+++ b/voxelmanip.lua
@@ -33,12 +33,6 @@ local function block_max_pos(bp)
 	return vector.add(block_min_pos(bp), core.MAP_BLOCKSIZE - 1)
 end
 
-local function sort_box(minp, maxp)
-	minp.x, maxp.x = math.min(minp.x, maxp.x), math.max(minp.x, maxp.x)
-	minp.y, maxp.y = math.min(minp.y, maxp.y), math.max(minp.y, maxp.y)
-	minp.z, maxp.z = math.min(minp.z, maxp.z), math.max(minp.z, maxp.z)
-end
-
 local ignore_node = {name = "ignore", param1 = 0, param2 = 0}
 
 local nodes_mt = {
@@ -56,9 +50,7 @@ function VoxelManip:get_emerged_area()
 end
 
 function VoxelManip:read_from_map(p1, p2)
-	local bpmin = pos2blockpos(p1)
-	local bpmax = pos2blockpos(p2)
-	sort_box(bpmin, bpmax)
+	local bpmin, bpmax = vector.sort(pos2blockpos(p1), pos2blockpos(p2))
 
 	local minp = block_min_pos(bpmin)
 	local maxp = block_max_pos(bpmax)

--- a/voxelmanip.lua
+++ b/voxelmanip.lua
@@ -17,6 +17,7 @@ mineunit("world")
 local rawget, rawset = rawget, rawset
 local hash_node_position = core.hash_node_position
 local get_content_id, get_name_from_content_id = core.get_content_id, core.get_name_from_content_id
+local vector_round = vector.round
 
 local VoxelManip = {}
 
@@ -117,7 +118,7 @@ function VoxelManip:update_map()
 end
 
 function VoxelManip:get_node_at(pos)
-	local node = self._nodes[hash_node_position(pos)]
+	local node = self._nodes[hash_node_position(vector_round(pos))]
 	return {name = node.name, param1 = node.param1, param2 = node.param2}
 end
 
@@ -126,7 +127,7 @@ function VoxelManip:set_node_at(pos, node)
 	if nodedef == nil then
 		error("Invalid node name '" .. tostring(node.name) .. "'")
 	end
-	self._nodes[hash_node_position(pos)] = {
+	self._nodes[hash_node_position(vector_round(pos))] = {
 		name = nodedef.name,
 		param1 = node.param1 or 0,
 		param2 = node.param2 or 0,

--- a/voxelmanip.lua
+++ b/voxelmanip.lua
@@ -1,3 +1,14 @@
+-- The VoxelManip stores nodes in a map from position hashes to node tables,
+-- just like the world at large. It may share node tables with the world, so
+-- these tables must be immutable.
+--
+-- Incompatibilities with real VoxelManip:
+-- 1. Mapgen methods not implemented.
+-- 2. Light and liquid updates no-ops.
+-- 3. If there are holes in the VoxelManip data due to multiple calls to
+--    read_from_map(), the placeholder data in these holes cannot be changed by
+--    set_data() etc. This is very unlikely to be a problem.
+
 mineunit("common/vector")
 mineunit("game/misc")
 mineunit("world")

--- a/world.lua
+++ b/world.lua
@@ -17,6 +17,7 @@ function world.clear()
 			rawset(self, key, node)
 		end,
 	})
+	-- These nodes must not mutate.
 	world.nodes = nodes
 end
 
@@ -33,6 +34,7 @@ local function create_node(node, defaults)
 	node = type(node) == "table" and node or { name = node }
 	return {
 		name = node.name and node.name or (defaults and defaults.name),
+		param1 = node.param1 and node.param1 or (defaults and defaults.param1 or 0),
 		param2 = node.param2 and node.param2 or (defaults and defaults.param2 or 0),
 	}
 end
@@ -75,7 +77,8 @@ function world.set_default_node(node)
 end
 
 function world.get_node(pos)
-	return world.nodes[core.hash_node_position(vector.round(pos))]
+	local node = world.nodes[core.hash_node_position(vector.round(pos))]
+	return node and {name = node.name, param1 = node.param1, param2 = node.param2}
 end
 
 -- set_node sets world node without place/dig callbacks
@@ -251,7 +254,7 @@ function world.add_layout(layout, offset)
 		for x = p1.x, p2.x do
 			for y = p1.y, p2.y do
 				for z = p1.z, p2.z do
-					world.set_node({x=x, y=y, z=z}, {name=node[2], param2=0})
+					world.set_node({x=x, y=y, z=z}, {name=node[2], param1=0, param2=0})
 				end
 			end
 		end


### PR DESCRIPTION
Changes:
* Implements VM functionality that is not exclusive to mapgen VMs.
* Implements param1 support.
* Makes copies of nodes returned by `world.get_node` (for safety/correctness.)

Tests have been added for voxel manipulators.