### PR TITLE
Remove unnecessary VoxelManip dependencies

### DIFF
--- a/spec/voxelmanip_spec.lua
+++ b/spec/voxelmanip_spec.lua
@@ -7,8 +7,6 @@ describe("VoxelManip", function()
 	require("mineunit")
 	sourcefile("voxelmanip")
 	mineunit("core")
-	mineunit("common/vector")
-	mineunit("world")
 
 	mineunit:set_current_modname("test")
 	minetest.register_node("test:node", {})

--- a/voxelmanip.lua
+++ b/voxelmanip.lua
@@ -9,10 +9,7 @@
 --    read_from_map(), the placeholder data in these holes cannot be changed by
 --    set_data() etc. This is very unlikely to be a problem.
 
-mineunit("common/vector")
 mineunit("core")
-mineunit("game/misc")
-mineunit("world")
 
 local rawget, rawset = rawget, rawset
 local hash_node_position = core.hash_node_position


### PR DESCRIPTION
Some of the declared dependencies were not necessary, since `core` covers the rest. `core` itself is necessary for `get_content_id`.