### PR TITLE
Few small fixes / improvements

### DIFF
--- a/auth.lua
+++ b/auth.lua
@@ -14,7 +14,7 @@ mineunit.export_object(AuthEntry, {
 	name = "AuthEntry",
 	typename = "table",
 	constructor = function(self, name)
-		assert(type(name) == "string")
+		assert(type(name) == "string" and name ~= "", "Invalid AuthEntry name '"..tostring(name).."'")
 		local obj = {}
 		local player = mineunit:get_players()[name]
 		assert.is_player(player)

--- a/player.lua
+++ b/player.lua
@@ -60,7 +60,8 @@ function _G.core.get_player_by_name(name)
 end
 
 function _G.core.get_player_ip(name)
-	return core.get_player_by_name(name)._address
+	local player = core.get_player_by_name(name)
+	return player and player._address or nil
 end
 
 function _G.core.get_connected_players()


### PR DESCRIPTION
* core.get_player_ip(...): handle missing player.
* mineunit:execute_on_joinplayer(...): execute registered_on_prejoinplayers + allow setting IP and other details + better assertion messages.
* Better AuthEntry assertion messages.
* Fix apparent wrong variable name in ABM match_nodes helper.

`mineunit("auth")` is required to execute `core.register_on_prejoinplayer(function)` callbacks, injects single globalstep after successful prejoin callbacks but before executing `core.register_on_joinplayer(function)` callbacks.

`mineunit:execute_on_joinplayer(player, lastlogin)` signature changed to `mineunit:execute_on_joinplayer(player, options)` where options is table.

* Old call `mineunit:execute_on_joinplayer(player, 1234)` should be replaced with
* new call `mineunit:execute_on_joinplayer(player, {lastlogin=1234})`

No Backwards compatibility.

Fixes #86 