### PR TITLE
Fix self tests

### DIFF
--- a/.github/workflows/mineunit.yml
+++ b/.github/workflows/mineunit.yml
@@ -1,4 +1,3 @@
-
 name: mineunit
 
 on: [push, pull_request]
@@ -8,6 +7,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: mt-mods/mineunit-actions@badger
+    - id: mineunit
+      uses: mt-mods/mineunit-actions@master
+    - uses: RubbaBoy/BYOB@v1.3.0
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       with:
-        badge-secret: ${{ secrets.MineunitBadgesAPIKey }}
+        NAME: "${{ steps.mineunit.outputs.badge-name }}"
+        LABEL: "${{ steps.mineunit.outputs.badge-label }}"
+        STATUS: "${{ steps.mineunit.outputs.badge-status }}"
+        COLOR: "${{ steps.mineunit.outputs.badge-color }}"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: KeisukeYamashita/create-comment@v1
+      if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      with:
+        check-only-first-line: true
+        comment: |
+          ## Some tests failed, test log follows:
+          ```
+          ${{ steps.mineunit.outputs.mineunit-stdout }}
+          ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mineunit
 Minetest core / engine libraries for regression tests
 
-![mineunit](https://mineunit-badges.000webhostapp.com/S-S-X/mineunit/coverage)
+![](https://byob.yarr.is/S-S-X/mineunit/coverage)
 
 Probably will not currently work with Windows so unless you want to help fixing things use Linux or similar OS.
 
@@ -129,7 +129,7 @@ Mineunit itself comes with some additional functionality to allow controlled tes
 | `mineunit:execute_globalstep(dtime)`                            | Execute Minetest globalstep: will trigger registered globalsteps, nodetimers, minetest.after and similar callbacks.
 | `mineunit:mods_loaded()`                                        | Execute functions registered with `minetest.register_on_mods_loaded(func)`.
 | `mineunit:execute_shutdown()`                                   | Simulate server shutdown event.
-| `mineunit:execute_on_joinplayer(player, lastlogin)`             | Simulate `Player` joining the game.
+| `mineunit:execute_on_joinplayer(player, options)`               | Simulate `Player` joining the game. Use `options` table for details like `address` and `lastlogin`.
 | `mineunit:execute_on_leaveplayer(player, timeout)`              | Simulate `Player` leaving the game.
 | `mineunit:execute_on_chat_message(sender, message)`             | Simulate `Player` sending chat message.
 | `mineunit:execute_modchannel_message(channel, sender, message)` | Modchannel message handlers.


### PR DESCRIPTION
Experimental Mineunit actions badger branch have not received required maintenance work and badge redirect server is down (actually I've removed server completely).

Badger stuff was experimental anyway and not ready for real use, backend was running PHP instead of originally planned HAProxy as a web server (with backend only for updates). Maybe it'll be restored some day using better stack, reason for PHP was mostly that it runs almost anywhere (when talking about generic web hosting).

Now use what projects using MIneunit are also using.