### PR TITLE
Add some missing core functions

### DIFF
--- a/assert.lua
+++ b/assert.lua
@@ -249,7 +249,10 @@ end
 
 local function resolve_args_inv_list_slot_stack(a, b, c, d)
 	local inv
-	if mineunit_type(a) == "Player" then
+	local atype = mineunit_type(a)
+	if atype == "InvRef" then
+		inv = a
+	elseif atype == "Player" or atype == "MetaDataRef" then
 		inv = a:get_inventory()
 	elseif is_coordinate(a) then
 		inv = world.get_meta(a):get_inventory()
@@ -263,7 +266,11 @@ end
 
 local function formatname(thing)
 	local mtype = mineunit_type(thing)
-	if mtype == "Player" then
+	if mtype == "InvRef" then
+		return "InvRef" -- .. next(assert.is_table(rawget(thing, "_lists")))
+	elseif mtype == "MetaDataRef" then
+		return "MetaDataRef"
+	elseif mtype == "Player" then
 		return thing:get_player_name()
 	elseif mtype == "ItemStack" then
 		return thing:get_name()
@@ -275,6 +282,12 @@ local function formatname(thing)
 	error("formatname: unsupported thing")
 end
 
+-- has_item(InfRef, listname, slotnumber, itemstring|ItemStack)
+-- has_item(InfRef, listname, itemstring|ItemStack)
+-- has_item(InfRef, itemstring|ItemStack)
+-- has_item(MetaDataRef, listname, slotnumber, itemstring|ItemStack)
+-- has_item(MetaDataRef, listname, itemstring|ItemStack)
+-- has_item(MetaDataRef, itemstring|ItemStack)
 -- has_item(Player, listname, slotnumber, itemstring|ItemStack)
 -- has_item(Player, listname, itemstring|ItemStack)
 -- has_item(Player, itemstring|ItemStack)

--- a/bin/mineunit
+++ b/bin/mineunit
@@ -359,14 +359,20 @@ do -- Parse cli args
 			doc("MetaDataRef", "thing", "Thing is valid MetaData class instance.")
 			doc("NodeMetaRef", "thing", "Thing is valid NodeMeta class instance.")
 			doc("Player", "thing", "Thing is valid Player class instance.")
+			doc("has_item", "Inventory", "itemstring|ItemStack", "")
+			doc("has_item", "Inventory", "listname", "itemstring|ItemStack", "")
+			doc("has_item", "Inventory", "listname", "slotnumber", "itemstring|ItemStack", "")
 			doc("has_item", "Player", "itemstring|ItemStack", "")
 			doc("has_item", "Player", "listname", "itemstring|ItemStack", "")
 			doc("has_item", "Player", "listname", "slotnumber", "itemstring|ItemStack", "")
+			doc("has_item", "MetaData", "itemstring|ItemStack", "")
+			doc("has_item", "MetaData", "listname", "itemstring|ItemStack", "")
+			doc("has_item", "MetaData", "listname", "slotnumber", "itemstring|ItemStack", "")
 			doc("has_item", "coordinate", "itemstring|ItemStack)", "")
 			doc("has_item", "coordinate", "listname", "itemstring|ItemStack", "")
 			doc("has_item", "coordinate", "listname", "slotnumber", "itemstring|ItemStack", "Check that player "..
-				"inventory or world position contains specified item. Optionally restricting to named inventory list "..
-				"and optional slot number.")
+				"inventory, bare inventory, metadata or world position contains specified item." ..
+				" Optionally restricting to named inventory list and optional slot number.")
 			print("\nAssertions can be prefixed with is_ (default) or not_ modifiers.")
 			print("Special assertions are provided in addition to luassert builtin assertions.")
 			print("Most assertions accept one additional argument besides what has been")

--- a/core.lua
+++ b/core.lua
@@ -78,6 +78,7 @@ _G.minetest.add_particlespawner = noop
 _G.minetest.registered_chatcommands = {}
 _G.minetest.register_chatcommand = noop
 _G.minetest.chat_send_player = function(...) print(unpack({...})) end
+_G.minetest.chat_send_all = function(...) print(unpack({...})) end
 _G.minetest.register_on_placenode = noop
 _G.minetest.register_on_dignode = noop
 _G.minetest.register_on_mods_loaded = function(func) mineunit:register_on_mods_loaded(func) end

--- a/core.lua
+++ b/core.lua
@@ -70,6 +70,41 @@ _G.core.get_mod_storage = function()
 	return mod_storage[modname]
 end
 
+-- Detached inventories
+local inv_storage = {}
+_G.core.get_inventory = function(where)
+	assert.is_hashed(where)
+	assert.is_string(where.name)
+	if where.type == "detached" then
+		return inv_storage[where.name]
+	elseif where.type == "node" then
+		assert.is_coordinate(where.pos)
+		local meta = core.get_meta(where.pos)
+		return meta and meta:get_inventory() or nil
+	elseif where.type == "player" then
+		local player = core.get_player_by_name(where.name)
+		return player and player:get_inventory() or nil
+	end
+	error("core.get_inventory(): Invalid inventory type")
+end
+_G.core.create_detached_inventory = function(name, callbacks, player_name)
+	assert.is_string(name)
+	mineunit:debugf("core.create_detached_inventory(): initializing new detached inventory '%s'", name)
+	if player_name then
+		mineunit:warningf("core.create_detached_inventory(): ignoring player_name '%s'", player_name)
+	end
+	inv_storage[name] = InvRef()
+	return inv_storage[name]
+end
+_G.core.remove_detached_inventory = function(name)
+	assert.is_string(name)
+	if inv_storage[name] then
+		inv_storage[name] = nil
+		return true
+	end
+	return false
+end
+
 _G.minetest.sound_play = noop
 _G.minetest.sound_stop = noop
 _G.minetest.sound_fade = noop


### PR DESCRIPTION
* core.chat_send_all
* core.get_inventory
* core.create_detached_inventory
* core.remove_detached_inventory

Also makes `assert.has_item` compatible with `InvRef` and `MetaDataRef` in addition to previous `Player` instance and node coordinates.

- [x] Validate behavior, probably very wrong for parts of inventory stuff.
- [x] Fix and finish tests.